### PR TITLE
Uploading release artifacts

### DIFF
--- a/.github/workflows/Docker.yml
+++ b/.github/workflows/Docker.yml
@@ -64,11 +64,26 @@ jobs:
       run: |
         docker run --entrypoint /bin/bash -v $(realpath ${{ github.workspace }}/packages):/packages clickhouse_odbc_tester:${{ matrix.odbc_provider }}-${{ matrix.base_os }} -c 'cd clickhouse-odbc-build && ls -lah && ninja package ||: ; mv clickhouse-odbc-* /packages && ls -lah /packages'
 
+    - name: List artifacts
+      run: |
+        echo REF: ${{ github.ref }}
+        ls -lahR ${{ github.workspace }}/packages/
+
     - name: Upload the artifacts
       uses: actions/upload-artifact@v3
       with:
           name: clickhouse-odbc-${{ matrix.base_os }}-${{ matrix.odbc_provider }}
           path: ${{ github.workspace }}/packages/*tar.gz*
+
+    - name: Upload artifacts as release assets
+      if: ${{ github.event_name == 'release' }}
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: ${{ github.workspace }}/packages/clickhouse-odbc-*
+        overwrite: true
+        tag: ${{ github.ref }}
+        file_glob: true
 
     # - name: Test - Run unit tests
     #   run: docker run --network=host clickhouse_odbc_tester:${{ matrix.odbc_provider }} -R '.*-ut.*'

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -122,11 +122,19 @@ jobs:
     - name: Package
       run: cmake --build ${{ github.workspace }}/build --config ${{ matrix.build_type }} --target package
 
+    - name: List artifacts
+      run: |
+        echo REF: ${{ github.ref }}
+        ls -lahR ${{ github.workspace }}/build/
+
+    # Linux release artifacts are uploaded in Docker.yml
+    # That builds binaries based on CentOS 7, which makes those more portable.
+    # However, these binaries are uploaded to be available in GH's 'Actions', just in case.
     - name: Upload the artifacts
-      if:  ${{ matrix.os == 'ubuntu-18.04' && matrix.compiler == 'GCC' && matrix.odbc_provider == 'UnixODBC' && matrix.build_type == 'Release' && matrix.runtime_link == 'dynamic-runtime' && matrix.third_parties == 'bundled-third-parties' }}
+      if:  ${{ matrix.compiler == 'GCC' && matrix.odbc_provider == 'UnixODBC' && matrix.build_type == 'Release' && matrix.runtime_link == 'dynamic-runtime' && matrix.third_parties == 'bundled-third-parties' }}
       uses: actions/upload-artifact@v3
       with:
-          name: clickhouse-odbc-linux
+          name: clickhouse-odbc-linux-${{ matrix.compiler }}-${{ matrix.odbc_provider }}-${{ matrix.build_type }}
           path: ${{ github.workspace }}/build/clickhouse-odbc-*
 
     - name: Test - Run unit tests

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -85,11 +85,16 @@ jobs:
     - name: Package
       run: cmake --build ${{ github.workspace }}/build --config ${{ matrix.build_type }} --target package
 
+    - name: List artifacts
+      run: |
+        echo REF: ${{ github.ref }}
+        dir ${{ github.workspace }}/build
+
     - name: Upload the artifacts
-      if:  ${{ matrix.os == 'windows-2016' && matrix.build_type == 'Release' }}
+      # if:  ${{ matrix.os == 'windows-2019' && matrix.build_type == 'Release' }}
       uses: actions/upload-artifact@v3
       with:
-          name: clickhouse-odbc-windows
+          name: clickhouse-odbc-windows-${{ matrix.architecture }}-${{ matrix.build_type }}
           path: ${{ github.workspace }}/build/clickhouse-odbc-*
 
     - name: Test - Run unit tests
@@ -180,3 +185,13 @@ jobs:
 
     #     # Run all tests except those that were run in "Test - unit tests" step.
     #     ctest --output-on-failure --build-config ${{ matrix.build_type }} -E '.*-ut.*'
+
+    - name: Upload artifacts as release assets
+      if: ${{ github.event_name == 'release' && matrix.build_type == 'Release' }}
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: ${{ github.workspace }}/build/clickhouse-odbc-*
+        overwrite: true
+        tag: ${{ github.ref }}
+        file_glob: true

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -1,0 +1,11 @@
+# Log all debug info to facilitate debugging
+name: debug
+
+'on':
+  [push, pull_request, release]
+
+jobs:
+  DebugInfo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: hmarr/debug-action@v2.0.1

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -112,11 +112,16 @@ jobs:
     - name: Package
       run: cmake --build ${{ github.workspace }}/build --config ${{ matrix.build_type }} --target package
 
+    - name: List artifacts
+      run: |
+        echo REF: ${{ github.ref }}
+        ls -lahR ${{ github.workspace }}/build
+
     - name: Upload the artifacts
-      if:  ${{ matrix.compiler == 'AppleClang' && matrix.odbc_provider == 'iODBC' && matrix.build_type == 'Release' }}
+      # if:  ${{ matrix.compiler == 'AppleClang' && matrix.odbc_provider == 'iODBC' && matrix.build_type == 'Release' }}
       uses: actions/upload-artifact@v3
       with:
-          name: clickhouse-odbc-macos
+          name: clickhouse-odbc-macos-${{ matrix.compiler }}-${{ matrix.odbc_provider }}-${{ matrix.build_type }}
           path: ${{ github.workspace }}/build/clickhouse-odbc-*
 
     - name: Test - Run unit tests
@@ -205,3 +210,13 @@ jobs:
 
     #     # Run all tests except those that were run in "Test - unit tests" step.
     #     ctest --output-on-failure --build-config ${{ matrix.build_type }} -E '.*-ut.*'
+
+    - name: Upload artifacts as release assets
+      if: ${{ github.event_name == 'release' && matrix.build_type == 'Release' }}
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: ${{ github.workspace }}/build/clickhouse-odbc-*
+        overwrite: true
+        tag: ${{ github.ref }}
+        file_glob: true


### PR DESCRIPTION
Uploading Release binaries of Windows and macOS from corresponding workflows.
Linux binaries are uploaded from Docker workflow since it builds\tests binaries on CentOS 7, making those more portable.